### PR TITLE
Bulk IGC upload: get the right bit of the track file name as HGFA#

### DIFF
--- a/bulk_igc_reader.pl
+++ b/bulk_igc_reader.pl
@@ -59,9 +59,8 @@ sub extract_igcs
 
         if (scalar @names > 0)
         {
-            $pilPk = 0 + $fields[0];
-            
-            #print "found: $pilPk\n";
+            $pilPk = 0 + $names[1];
+            print "Supposed HGFA # as found in the file name $file: $pilPk\n";
         }
 
         if ($pilPk > 0)


### PR DESCRIPTION
A simple fix to bulk igc upload, so a file generated by the "tracks download" feature can be uploaded into another instance