### PR TITLE
Add 'Download Registered Pilots' button to the Registration page

### DIFF
--- a/bulk_pilot_import.pl
+++ b/bulk_pilot_import.pl
@@ -8,6 +8,7 @@
 require DBD::mysql;
 use Data::Dumper;
 use Text::CSV qw( csv );
+use Scalar::Util qw(looks_like_number);
 use TrackLib qw(:all);
 
 #
@@ -33,14 +34,19 @@ sub read_membership
     {
         $row = $_;
 
-        print "row=$row\n";
-
         @field = split /,/, $row;
         if ($field[1] eq '')
         {
             next;
         }
-        print 'add name: ', $field[1], ' ', $field[0], "\n";
+
+        if(!looks_like_number($field[2]) || !looks_like_number($field[4]))
+        {
+            next;
+        }
+
+        print "row=$row";
+        print 'add name: ', $field[1], ' ', $field[0], "\n\n";
 
         # should be an insert/update ..
         insertup('tblPilot', 'pilPk', "pilLastName='" . $field[0] . 

--- a/download_registered_pilots.php
+++ b/download_registered_pilots.php
@@ -1,0 +1,37 @@
+<?php
+
+require 'authorisation.php';
+require 'xcdb.php';
+
+$comPk=reqival('comPk');
+
+$link = db_connect();
+$usePk = check_auth('system');
+if (!is_admin('admin',$usePk,$comPk))
+{
+    echo "unauthorised";
+    return;
+}
+
+$sql = "SELECT p.* FROM tblRegistration r JOIN tblPilot p ON r.pilPk = p.pilPk WHERE r.comPk = $comPk";
+$result = mysql_query($sql,$link) or die("Unable to find pilots: " . mysql_error() . "\n");
+
+header("Content-type: text/igc");
+header("Cache-Control: no-store, no-cache");
+header("Content-Disposition: attachment; filename=registered-pilots-$comPk.csv");
+print "Last,First,HGFA#,Sex,CIVL#\r\n";
+
+while($row = mysql_fetch_array($result, MYSQL_ASSOC)) {
+    print $row['pilLastName'];
+    print ",";
+    print $row['pilFirstName'];
+    print ",";
+    print $row['pilHGFA'];
+    print ",";
+    print $row['pilSex'];
+    print ",";
+    print $row['pilCIVL'];
+    print "\r\n";
+}
+
+?>

--- a/pilot_admin.php
+++ b/pilot_admin.php
@@ -165,7 +165,7 @@ if (reqexists('bulkadd'))
     //echo "bulk_pilot_import.pl $copyname<br>";
     chmod($copyname, 0644);
 
-    exec(BINDIR . "bulk_pilot_import.pl $copyname", $out, $retv);
+    exec(BINDIR . "bulk_pilot_import.pl $copyname 2>&1", $out, $retv);
     foreach ($out as $txt)
     {  
         echo "$txt<br>\n";
@@ -228,7 +228,7 @@ echo "FirstName: " . fin('fname', '', 10);
 echo "Sex: " . fselect('sex', 'M', [ 'M' => 'M', 'F' => 'F' ]);
 echo fis('addpilot', "Add Pilot", 5); 
 echo "<br>";
-echo "CSV (Last,First,FAI#,Sex,CIVL#): <input type=\"file\" name=\"bulkpilots\">";
+echo "CSV (Last,First,HGFA#,Sex,CIVL#): <input type=\"file\" name=\"bulkpilots\">";
 echo fis('bulkadd', 'Bulk Submit', 5);
 
 if ($ozimp)

--- a/registration.php
+++ b/registration.php
@@ -42,6 +42,10 @@ if ($comRestricted == 'open')
 }
 
 echo "<p><h2>Registration - $comName</h2></p>";
+echo "<form enctype=\"multipart/form-data\" action=\"download_registered_pilots.php?comPk=$comPk\" name=\"trackadmin\" method=\"post\">";
+echo fis('download_pilots', 'Download Registered Pilots', 15);
+echo "</form>";
+
 $usePk = auth('system');
 $cat = addslashes($_REQUEST['cat']);
 if ($cat == '')


### PR DESCRIPTION
Add 'Download Registered Pilots' button to the Registration page, skip records without numeric HGFA or CIVL numbers on bulk pilots CSV uploads (e.g. header)

![image](https://user-images.githubusercontent.com/5769929/229795564-ca47e449-0737-4eeb-a9a8-7e6a45ff5f92.png)

