### PR TITLE
Fix issue with exist waypoints in adding new task

### DIFF
--- a/add_task.php
+++ b/add_task.php
@@ -125,7 +125,7 @@ function add_xctrack_task($link, $tmpfile, $comPk, $name, $regPk, $createwpts, $
         }
         else
         {
-            $wtype = $waytype[$wpt['type']];
+            $wtype = $waytype[$wpt['type']] ?? "'waypoint'";
         }
         
         // PEDRO:


### PR DESCRIPTION
I introduced a bug when calculating the direction of the waypoint crossing. If we have an exit waypoint, the logic break, this fixes it.