### PR TITLE
Fix cylinders borders visual inaccuracy

### DIFF
--- a/airgain_map.html
+++ b/airgain_map.html
@@ -79,7 +79,7 @@
     <script src="vendor/jquery/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
     <script src="vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
-    <script src="js/map_services.js"></script>
+    <script src="js/map_services.js?v=2"></script>
     <script src="js/airspace_services.js"></script>
     <script src="js/plot_airgain.js"></script>
     <script src="js/plot_tracks_airgain.js?v=3"></script>

--- a/airspace_map.html
+++ b/airspace_map.html
@@ -73,7 +73,7 @@
     <script src="vendor/jquery/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
     <script src="vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
-    <script src="js/map_services.js"></script>
+    <script src="js/map_services.js?v=2"></script>
     <script src="js/airspace_services.js"></script>
     <script src="js/plot_airspace.js"></script>
   </body>

--- a/js/map_services.js
+++ b/js/map_services.js
@@ -294,6 +294,36 @@ function add_award_task(tasPk, trackid)
     }
     });
 }
+
+function faiSphereDistance(lat1, lon1, lat2, lon2) {
+  // The Haversine equation
+
+  var R = 6371; // Earth radius in km
+
+  var toRad = function(deg) { return deg * Math.PI / 180; };
+
+  var phi1 = toRad(lat1);
+  var phi2 = toRad(lat2);
+  var deltaPhi = toRad(lat2 - lat1);
+  var deltaLambda = toRad(lon2 - lon1);
+
+  var aRaw =
+    Math.pow(Math.sin(deltaPhi / 2), 2) +
+    Math.cos(phi1) * Math.cos(phi2) *
+    Math.pow(Math.sin(deltaLambda / 2), 2);
+
+  // Clamp because floating-point rounding can make aRaw
+  // slightly outside [0, 1], which could cause NaN
+  var a = Math.min(1, Math.max(0, aRaw));
+
+  var c = 2 * Math.atan2(
+    Math.sqrt(a),
+    Math.sqrt(1 - a)
+  );
+
+  return R * c * 1000.0; // return in meters
+}
+
 function plot_task_route(map, ssr)
 {
     line = Array();
@@ -309,16 +339,16 @@ function plot_task_route(map, ssr)
         var circle;
         lasLat = ssr[row]["rwpLatDecimal"];
         lasLon = ssr[row]["rwpLongDecimal"];
-        sLat = ssr[row]["ssrLatDecimal"];
-        sLon = ssr[row]["ssrLongDecimal"];
+        sLat = ssr[row]["ssrLatDecimal"]; // optimised point
+        sLon = ssr[row]["ssrLongDecimal"]; // optimised point
         cname = count + ".&nbsp;" + ssr[row]["rwpName"];
         crad = ssr[row]["tawRadius"];
         shape = ssr[row]["tawShape"];
 
-        gll = new L.LatLng(lasLat, lasLon);
+        gll = new L.LatLng(lasLat, lasLon); // cylinder centre
         line.push(gll);
 
-        sll = new L.LatLng(sLat, sLon);
+        sll = new L.LatLng(sLat, sLon); // optimised point
         if (!pbounds)
         {
             pbounds = new L.LatLngBounds(gll, sll);
@@ -327,7 +357,7 @@ function plot_task_route(map, ssr)
         {
             pbounds.extend(sll);
         }
-        sline.push(sll);
+        sline.push(sll); // optimised line
       
         count = count + 1;    
   
@@ -367,15 +397,28 @@ function plot_task_route(map, ssr)
         }
         else
         {
-            var adjrad = parseInt(crad);
-            adjrad = adjrad;
-            if (adjrad > 10000)
-            {
-                // try to compensate for google maps inaccuracies with large cylinders
-                adjrad = adjrad * 0.999;
+            var origRad = parseInt(crad);
+
+            // Use optimised point as a reference to get the proper cylinder radius. The map API
+            // uses "fai sphere"-like distance calc to draw a cirle, which is different from the
+            // calculation used to get the optimised point. So, get the distance between the
+            // optimised point and the centre on the FAI sphere - this gives the radius for the
+            // circle, required to put its edge right on the optimised point:
+            var adjRad = faiSphereDistance(lasLat, lasLon, sLat, sLon);
+
+            if (isNaN(adjRad) || Math.abs(adjRad - origRad) > origRad * 0.2) {
+                // adjRad is zero for the start point which is ok,
+                // let's give some margin (in meters) for rounding when checking for outliers:
+                if (adjRad > 1) {
+                    console.warn("Calculated radius " + adjRad +
+                      " differs significantly from original " + origRad + " for point " + cname +
+                      ". Using original radius.");
+                }
+
+                adjRad = origRad;
             }
             circle = new L.Circle(pos, {
-                radius:adjrad,
+                radius:adjRad,
                 stroke:true,
                 color:"#ff0000",
                 opacity:1.0,

--- a/olc_overview.html
+++ b/olc_overview.html
@@ -73,7 +73,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
     <script src="vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
     <script src="vendor/fullscreen/Leaflet.fullscreen.min.js"></script>
-    <script src="js/map_services.js"></script>
+    <script src="js/map_services.js?v=2"></script>
     <script src="js/olc_overview.js"></script>
   </body>
 </html>

--- a/task_overview.html
+++ b/task_overview.html
@@ -83,7 +83,7 @@
     <script src="vendor/fullscreen/Leaflet.fullscreen.min.js"></script>
     <script src="vendor/js/leaflet-ruler.js"></script>
     <script src="js/airspace_services.js?v=1"></script>
-    <script src="js/map_services.js?v=1"></script>
+    <script src="js/map_services.js?v=2"></script>
     <script src="js/task_overview_leaf.js?v=19"></script>
   </body>
 </html>

--- a/track_overview.html
+++ b/track_overview.html
@@ -81,7 +81,7 @@
     <script src="vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
     <script src="vendor/fullscreen/Leaflet.fullscreen.min.js"></script>
     <script src="vendor/js/leaflet-ruler.js"></script>
-    <script src="js/map_services.js"></script>
+    <script src="js/map_services.js?v=2"></script>
     <script src="js/track_overview_leaf.js"></script>
 
   </body>

--- a/tracklog_map.html
+++ b/tracklog_map.html
@@ -81,7 +81,7 @@
     <script src="vendor/jquery/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
     <script src="vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
-    <script src="js/map_services.js?v=10"></script>
+    <script src="js/map_services.js?v=2"></script>
     <script src="js/airspace_services.js"></script>
     <script src="js/plot_track_lf.js?v=5"></script>
     <script src="js/uair_lf.js"></script>

--- a/waypoint_map.html
+++ b/waypoint_map.html
@@ -103,7 +103,7 @@
     <script src="vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
     <script src="vendor/js/leaflet-ruler.js"></script>
     <script src="js/jquery.ajax-cross-origin.min.js"></script>
-    <script src="js/map_services.js"></script>
+    <script src="js/map_services.js?v=2"></script>
     <script src="js/srtm.js"></script>
     <script src="js/pop_waypoints.js?v=2"></script>
 


### PR DESCRIPTION
Changes cylinder radius so its edge is right on the optimised point.

Here is comparison with the shortest distance line. The optimised line is not moved, but the cylinder edge is:

Old:
<img width="458" height="432" alt="image" src="https://github.com/user-attachments/assets/0c8e42f8-2525-4554-b293-e13eb6334043" />
New:
<img width="331" height="341" alt="image" src="https://github.com/user-attachments/assets/e2b22bb6-b40d-4973-b495-dbde240cb141" />


And one more comparison with a track. Again, the track not moved, but the cylinder edge is:

Old:
<img width="335" height="482" alt="image" src="https://github.com/user-attachments/assets/6c74de44-ade0-48f6-93e0-7b85f645f425" />

New:
<img width="304" height="401" alt="image" src="https://github.com/user-attachments/assets/eb6cae90-7605-4b8b-9c2f-ed64b396ae08" />
